### PR TITLE
Handling spaces before colon

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -24,7 +24,7 @@ export const mapCss = (data: any, debug?: boolean): object => {
 };
 
 export const cleanValue = (val: string): string | void => {
-  const matches = val.match(/content:\s*"\\f([^"]+)"/i);
+  const matches = val.match(/content\s*:\s*"\\f([^"]+)"/i);
   if (matches) {
     return `\\uf${matches[1]}`;
   }


### PR DESCRIPTION
This PR makes CSS parsing better in terms of handling space (s) before colon:

Before PR the following CSS won't be parsed:
```
.fa-glass:before {
  content : "\f000";
}
```

Notice a space before `:`. It may save a few hours in troubleshooting why stylesheet is not mapped.