### PR TITLE
Loosen matching criteria for font icon characters

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -24,9 +24,9 @@ export const mapCss = (data: any, debug?: boolean): object => {
 };
 
 export const cleanValue = (val: string): string | void => {
-  const matches = val.match(/content\s*:\s*"\\f([^"]+)"/i);
+  const matches = val.match(/content\s*:\s*"\\u*([^"]+)"/i);
   if (matches) {
-    return `\\uf${matches[1]}`;
+    return `\\u${matches[1]}`;
   }
   return void 0;
 };


### PR DESCRIPTION
Certain fonts, like material design icons, use characters whose encoding currently isn't recognized by the regex inside the `cleanValue` function. This change would allow the `content` property to include any character, even if the encoding doesn't start with `f`. It would also optionally allow a `u` to precede the encoding.

As an example, the css file included with the [nativescript-material-icons](https://github.com/shripalsoni04/nativescript-material-icons) library is compatible with `nativescript-ngx-fonticon` but not  with `nativescript-fonticon`. There may be other icon fonts that this applies to as well.