### PR TITLE
Added support for single quotes in css.

### DIFF
--- a/demo/app/font-awesome.css
+++ b/demo/app/font-awesome.css
@@ -1,8 +1,8 @@
 .fa-glass:before {
-  content: "\f000";
+  content: '\f000';
 }
 .fa-music:before {
-  content: "\f001";
+  content: '\f001';
 }
 .fa-search:before {
   content: "\f002";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -24,7 +24,7 @@ export const mapCss = (data: any, debug?: boolean): object => {
 };
 
 export const cleanValue = (val: string): string | void => {
-  const matches = val.match(/content\s*:\s*"\\f([^"]+)"/i);
+  const matches = val.match(/content\s*:\s*["|']\\f([^"|^']+)["|']/i)
   if (matches) {
     return `\\uf${matches[1]}`;
   }

--- a/src/test/cleanvalue.spec.ts
+++ b/src/test/cleanvalue.spec.ts
@@ -39,4 +39,11 @@ describe('Test cleanValue function', () => {
     );
   });
 
+  it('with single quotes', () => {
+    assert.strictEqual(
+      lib.cleanValue("content: '\\f000'; "),
+      '\\uf000',
+    );
+  });
+
 });

--- a/src/test/font-awesome.css
+++ b/src/test/font-awesome.css
@@ -11,4 +11,4 @@
 }
 .fa-gear:before, .fa-cog:before{ content:"\f013"; }
 .fa-rotate-right:before,.fa-repeat:before{content:"\f01e"}
-.fa-dedent:before,.fa-outdent:before{content:"\f03b"}.fa-photo:before,.fa-image:before,.fa-picture-o:before{content:"\f03e"}
+.fa-dedent:before,.fa-outdent:before{content:'\f03b'}.fa-photo:before,.fa-image:before,.fa-picture-o:before{content:'\f03e'}


### PR DESCRIPTION
Fixes #20.

Currently, the plugin doesn't support single quotes on CSS. This means that this doesn't work: 

```css
.fa-heart:before {
    content: '\f004';
}
```

This PR changes the `cleanValue` regex to support both `"` and `'`.

I added/changed tests and changed the demo app, so I know it works.

Thanks!

PS: The real reason why I made this PR is because I couldn't get prettier/eslint/vscode to stop converting `"` to `'` in my CSS file 😎...