### PR TITLE
Added support to unicode and single quote char in css

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -25,7 +25,7 @@ export const mapCss = (data: any, debug?: boolean): object => {
 
 export const cleanValue = (val: string): string | void => {
   const _v = val.replace(/(content\s*:\s*("|'))/, '').replace(/(("|');*)/, '').trim()
-  if (_v.length === 1) {
+  if (_v.includes('u')) {
       return _v
   } else {
       return `\\u${_v.substring(1)}`

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -24,9 +24,10 @@ export const mapCss = (data: any, debug?: boolean): object => {
 };
 
 export const cleanValue = (val: string): string | void => {
-  const matches = val.match(/content\s*:\s*"\\f([^"]+)"/i);
-  if (matches) {
-    return `\\uf${matches[1]}`;
+  const _v = val.replace(/(content\s*:\s*("|'))/, '').replace(/(("|');*)/, '').trim()
+  if (_v.length === 1) {
+      return _v
+  } else {
+      return `\\u${_v.substring(1)}`
   }
-  return void 0;
 };


### PR DESCRIPTION
In this pull-request:
- Changed the regex for reading the "content" value from css.
- Added support to single quotes `'`, together to double `"`.
- Added support to non-starting `\f` values eg. `\a584` or `\a584`.
- Added support for unicode values eg. `\ua584`.

Solved issues:
- #32
- #24 
- #23
- #20 
- #17